### PR TITLE
Fixing use of `Timeout`

### DIFF
--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentConnectionBase.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentConnectionBase.java
@@ -46,11 +46,15 @@ public class AgentConnectionBase {
   @ClassRule
   public static CheckIsDockerAvailable isDockerAvailable = new CheckIsDockerAvailable();
 
-  @Rule
+  @Rule(order = 10)
   public JenkinsRule j = new JenkinsRule();
 
-  @Rule
-  public Timeout globalTimeout= new Timeout(4, TimeUnit.MINUTES);
+  @Rule(order = -10)
+  public Timeout globalTimeout = Timeout.builder().withTimeout(10, TimeUnit.MINUTES).withLookingForStuckThread(true).build();
+
+  protected AgentConnectionBase() {
+      j.timeout = 0;
+  }
 
   protected boolean isSuccessfullyConnected(Node node) throws IOException, InterruptedException {
     int count = 0;


### PR DESCRIPTION
Still trying to fix timeouts occurring in CI from this plugin.

```bash
docker ps -aq | xargs docker rm -f
docker image ls --format {{.Repository}}:{{.Tag}} | egrep 'ssh-agent|testcontainers|ubuntu' | xargs docker image rm
docker image prune --force
mvn test -Dtest='hudson.plugins.sshslaves.agents.**.*Test'
```

shows the first test, `AgentCurve25519Sha256ConnectionTest`, taking >4m (`top` shows some `docker`, a lot of `dpkg`). Subsequent tests mostly run in <10s, so layer caching is effective.
