### PR TITLE
Suppress warnings for spotbugs 4.8.3

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
@@ -29,6 +29,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.trilead.ssh2.Connection;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.ItemGroup;
 import hudson.model.TaskListener;
@@ -69,6 +70,7 @@ public class SSHConnector extends ComputerConnector {
     /**
      * Field port
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public int port;
 
     /**

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -39,6 +39,7 @@ import com.trilead.ssh2.Session;
 import com.trilead.ssh2.jenkins.SFTPClient;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -152,6 +153,7 @@ public class SSHLauncher extends ComputerLauncher {
     /**
      * Field javaPath.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public String javaPath;
 
     /**
@@ -173,26 +175,31 @@ public class SSHLauncher extends ComputerLauncher {
     /**
      * Field prefixStartSlaveCmd.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public String prefixStartSlaveCmd;
 
     /**
      *  Field suffixStartSlaveCmd.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public String suffixStartSlaveCmd;
 
     /**
      *  Field launchTimeoutSeconds.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public Integer launchTimeoutSeconds;
 
     /**
      * Field maxNumRetries.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public Integer maxNumRetries;
 
     /**
      * Field retryWaitTime (seconds).
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public Integer retryWaitTime;
 
     // TODO: It is a bad idea to create a new Executor service for each launcher.


### PR DESCRIPTION
## Suppress warnings for spotbugs 4.8.3


https://github.com/jenkinsci/plugin-pom/pull/869 or a subsequent pull request that updates to 4.8.3 will need this change in the plugin to resolve new spotbugs warnings that will be reported by spotbugs 4.8.2 and later.

Plugin pom 4.77 is likely to include that new version of spotbugs.

### Testing done

Confirmed that the spotbugs warnings are visible when using the 4.77-SNAPSHOT plugin pom before this change. With this change, the spotbugs warnings are no longer visible.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
