### PR TITLE
Updates Java 11 to Java 17 for test environment

### DIFF
--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-curve25519-sha256/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-curve25519-sha256/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-dsa/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-dsa/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ec/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ec/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ecdh-sha2-nistp256/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ecdh-sha2-nistp256/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ecdh-sha2-nistp384/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ecdh-sha2-nistp384/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ecdh-sha2-nistp521/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ecdh-sha2-nistp521/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ed25519/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ed25519/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-host-ec/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-host-ec/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-host-ed/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-host-ed/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-host-rsa/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-host-rsa/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-rsa/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-rsa/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-rsa256/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-rsa256/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-rsa512/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-rsa512/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ubuntu-14.04/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ubuntu-14.04/Dockerfile
@@ -13,7 +13,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -36,7 +36,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ubuntu-16.04/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ubuntu-16.04/Dockerfile
@@ -13,7 +13,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -36,7 +36,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ubuntu-18.04/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ubuntu-18.04/Dockerfile
@@ -13,7 +13,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -36,7 +36,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ubuntu-20.04/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ubuntu-20.04/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
 RUN add-apt-repository ppa:openjdk-r/ppa -y \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --password password --shell /bin/bash --uid 1000 jenkins \
@@ -38,7 +38,7 @@ RUN echo "password\npassword" | passwd root \
   && echo "password\npassword" | passwd jenkins
 
 EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:/usr/lib/jvm/java-11-openjdk-amd64/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
 RUN echo "PATH=${PATH}" >> /etc/environment
 ENTRYPOINT []
 CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]


### PR DESCRIPTION
### Testing done
When running with Java 17 and a Jenkins Core built with `-Dmaven.compiler.target=17` tests are failing. This resolves the problem.
As Jenkins will be compiled with such option in just 20days, this is providing from prevention.
As you can see from this pull request build result, there is no problem with the current core requirement and those changes.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
