### PR TITLE
Fixed a couple of deprecation warnings

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
@@ -301,7 +301,7 @@ public class SSHConnector extends ComputerConnector {
             }
             return new StandardUsernameListBoxModel()
                     .includeMatchingAs(
-                            ACL.SYSTEM,
+                            ACL.SYSTEM2,
                             context,
                             StandardUsernameCredentials.class,
                             Collections.singletonList(SSHLauncher.SSH_SCHEME),

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -64,7 +64,6 @@ import hudson.util.DescribableList;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.NamingThreadFactory;
-import hudson.util.NullStream;
 import java.util.Collections;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
@@ -825,7 +824,7 @@ public class SSHLauncher extends ComputerLauncher {
             }
 
             // delete the agent jar as we do with SFTP
-            connection.exec("rm " + workingDirectory + SLASH_AGENT_JAR, new NullStream());
+            connection.exec("rm " + workingDirectory + SLASH_AGENT_JAR, OutputStream.nullOutputStream());
 
             // SCP it to the agent. hudson.Util.ByteArrayOutputStream2 doesn't work for this. It pads the byte array.
             listener.getLogger().println(Messages.SSHLauncher_CopyingAgentJar(getTimestamp()));
@@ -1253,7 +1252,7 @@ public class SSHLauncher extends ComputerLauncher {
                 int portValue = Integer.parseInt(port);
                 return new StandardUsernameListBoxModel()
                         .includeMatchingAs(
-                                ACL.SYSTEM,
+                                ACL.SYSTEM2,
                                 jenkins,
                                 StandardUsernameCredentials.class,
                                 Collections.singletonList(

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
@@ -42,6 +42,7 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -78,12 +79,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class SSHLauncherTest {
 
   @ClassRule
   public static BuildWatcher buildWatcher = new BuildWatcher();
+
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Rule
   public JenkinsRule j = new JenkinsRule();
@@ -167,7 +170,7 @@ public class SSHLauncherTest {
     SSHLauncher launcher = new SSHLauncher(host, 123, "dummyCredentialId");
     launcher.setSshHostKeyVerificationStrategy(new KnownHostsFileKeyVerificationStrategy());
     assertEquals(host.trim(), launcher.getHost());
-    DumbSlave agent = new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
+    DumbSlave agent = new DumbSlave("agent", temporaryFolder.newFolder().getAbsolutePath(), launcher);
     j.jenkins.addNode(agent);
 
     HtmlPage p = j.createWebClient().getPage(agent, "configure");
@@ -251,7 +254,7 @@ public class SSHLauncherTest {
     launcher.setLaunchTimeoutSeconds(5);
     launcher.setRetryWaitTime(5);
     launcher.setMaxNumRetries(2);
-    DumbSlave agent = new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
+    DumbSlave agent = new DumbSlave("agent", temporaryFolder.newFolder().getAbsolutePath(), launcher);
 
     Fingerprint fingerprint = CredentialsProvider.getFingerprintOf(credentials);
     assertThat("No fingerprint created until use", fingerprint, nullValue());
@@ -279,7 +282,7 @@ public class SSHLauncherTest {
     launcher.setLaunchTimeoutSeconds(5);
     launcher.setRetryWaitTime(5);
     launcher.setMaxNumRetries(2);
-    DumbSlave agent = new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
+    DumbSlave agent = new DumbSlave("agent", temporaryFolder.newFolder().getAbsolutePath(), launcher);
 
     Fingerprint fingerprint = CredentialsProvider.getFingerprintOf(credentials);
     assertThat("No fingerprint created until use", fingerprint, nullValue());
@@ -456,7 +459,7 @@ public class SSHLauncherTest {
     launcher.setLaunchTimeoutSeconds(5);
     launcher.setRetryWaitTime(1);
     launcher.setMaxNumRetries(3);
-    return new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
+    return new DumbSlave("agent", temporaryFolder.newFolder().getAbsolutePath(), launcher);
   }
 
   private void fakeCredentials(String id) {


### PR DESCRIPTION
Fixed a couple of deprecation warnings, including:
* using `ACL.SYSTEM2` instead of deprecated `ACL.SYSTEM`
* using `OutputStream.nullOutputStream()`
* using `TemporaryFolder` instead of deprecated `j.createTmpDir()`
* some raw use of parameterized class

### Testing done

All tests keep passing locally, the changes should not change anything.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
