### PR TITLE
Add ssh-ed25519 and ecdsa-sha2-nistp256 algorithms to ManuallyProvidedKeyVerificationStrategy SSH key help text

### DIFF
--- a/src/main/resources/hudson/plugins/sshslaves/verifiers/ManuallyProvidedKeyVerificationStrategy/help-key.html
+++ b/src/main/resources/hudson/plugins/sshslaves/verifiers/ManuallyProvidedKeyVerificationStrategy/help-key.html
@@ -1,1 +1,1 @@
-<p>The SSH key expected for this connection. This key should be in the form `<tt>algorithm value</tt>` where <tt>algorithm</tt> is one of <tt>ssh-rsa</tt> or <tt>ssh-dss</tt>, and <tt>value</tt> is the Base 64 encoded content of the key.</p>
+<p>The SSH key expected for this connection. This key should be in the form `<tt>algorithm value</tt>` where <tt>algorithm</tt> is one of <tt>ssh-rsa</tt>, <tt>ssh-ed25519</tt>, <tt>ecdsa-sha2-nistp256</tt> or <tt>ssh-dss</tt> and <tt>value</tt> is the Base 64 encoded content of the key.</p>


### PR DESCRIPTION
Currently ManuallyProvidedKeyVerificationStrategy `SSH key` help text only mentions `ssh-rsa` and `ssh-dss` while `ssh-ed25519` and `ecdsa-sha2-nistp256` are supported too. It made me spend too much time trying to debug why Jenkins could not establish connection using `ssh-rsa` key, while it was using `ssh-ed25519` and I had no idea I can put `ssh-ed25519` key there.

### Testing done

Don't think there is much to test

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

