### PR TITLE
feat: new workflow to build a SSH Agent Base Docker image

### DIFF
--- a/.github/workflows/ssh-agent-docker.yml
+++ b/.github/workflows/ssh-agent-docker.yml
@@ -43,7 +43,7 @@ jobs:
           tags: |
             type=raw,prefix=base,value=latest,enable={{is_default_branch}}
             type=ref,prefix=base,event=branch
-            type=ref,prefix=base,vent=pr
+            type=ref,prefix=base,event=pr
             type=sha,prefix=base
 
       - name: Build and push

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-base/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-base/Dockerfile
@@ -3,14 +3,17 @@ USER root
 
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN add-apt-repository ppa:openjdk-r/ppa -y
 RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
   && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq \
     --no-install-recommends \
     openssh-server \
     software-properties-common \
     git \
-    make \
+    make
+
+RUN add-apt-repository ppa:openjdk-r/ppa -y \
+  && DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
+  && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq \
     openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This new workflow will build an SSH Agent Docker image we can use to speed up the testcontainers tests.