### PR TITLE
feat: user prebuild base Docker image

### DIFF
--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-curve25519-sha256/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-curve25519-sha256/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,16 +9,4 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-dsa/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-dsa/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,16 +9,4 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ec/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ec/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,16 +9,4 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ecdh-sha2-nistp256/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ecdh-sha2-nistp256/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,16 +9,4 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ecdh-sha2-nistp384/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ecdh-sha2-nistp384/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,16 +9,4 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ecdh-sha2-nistp521/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ecdh-sha2-nistp521/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,16 +9,4 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ed25519/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ed25519/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,16 +9,4 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-host-ec/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-host-ec/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,18 +9,6 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]
 
 RUN rm /etc/ssh/ssh_host_ed* /etc/ssh/ssh_host_rsa*

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-host-ed/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-host-ed/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,18 +9,6 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]
 
 RUN rm /etc/ssh/ssh_host_ec* /etc/ssh/ssh_host_rsa*

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-host-rsa/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-host-rsa/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,18 +9,6 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]
 
 RUN rm /etc/ssh/ssh_host_ed* /etc/ssh/ssh_host_ec*

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-rsa/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-rsa/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,16 +9,4 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-rsa256/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-rsa256/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,16 +9,4 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-rsa512/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-rsa512/Dockerfile
@@ -1,25 +1,5 @@
-FROM ubuntu:24.04
+FROM ghcr.io/jenkinsci/ssh-agents-plugin:baseb2fb086@sha256:2bc6d82ca2b406b0a2b509fd2308c38ae51de9f3e61cb1288e3421f6116bb27c
 USER root
-
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y -qq \
-  &&  apt-get install -y -qq \
-    --no-install-recommends \
-    openssh-server \
-    software-properties-common \
-    git \
-    make
-
-RUN add-apt-repository ppa:openjdk-r/ppa -y \
-  && apt-get update -y -qq \
-  && apt-get install -y -qq \
-    openjdk-17-jdk \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN useradd --password password --shell /bin/bash jenkins \
-  && mkdir /home/jenkins \
-  && chown -R jenkins:jenkins /home/jenkins
 
 COPY ssh /home/jenkins/.ssh
 RUN chown -R jenkins:jenkins /home/jenkins/ \
@@ -29,16 +9,4 @@ COPY ssh /root/.ssh
 RUN chown -R root:root /root/ \
   && chmod 700 /root/.ssh \
   && chmod 600 /root/.ssh/*
-RUN ssh-keygen -A
 COPY ssh/sshd_config /etc/ssh/sshd_config
-
-RUN mkdir -p  /var/run/sshd
-
-RUN echo "password\npassword" | passwd root \
-  && echo "password\npassword" | passwd jenkins
-
-EXPOSE 22
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-17-openjdk-amd64/jre/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
-RUN echo "PATH=${PATH}" >> /etc/environment
-ENTRYPOINT []
-CMD [ "/bin/sh", "-c", "/usr/sbin/sshd -e -D -p 22"]

--- a/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ubuntu-20/Dockerfile
+++ b/src/test/resources/hudson/plugins/sshslaves/agents/ssh-agent-ubuntu-20/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:20.04
 USER root
 
 ENV TZ=Etc/UTC


### PR DESCRIPTION
Change to use a prebuilt Docker image to run the TestContainers tests. It will speed up the tests, and improve the reliability