### PR TITLE
chore: bump Jenkins Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
   <properties>
     <revision>3</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <hpi.compatibleSinceVersion>3.0.0</hpi.compatibleSinceVersion>
     <spotless.check.skip>false</spotless.check.skip>
     <no-test-jar>false</no-test-jar>


### PR DESCRIPTION
We bump the core ot support the two latest major versions from https://www.jenkins.io/changelog-stable/#v2.504.1 to [2.516.1](https://www.jenkins.io/changelog/2.516.1/).

This pull request updates the Jenkins baseline and version properties in the `pom.xml` file to align with a newer Jenkins version.

* **Jenkins version update**:
  * Updated the `jenkins.baseline` property from `2.479` to `2.504`.
  * Updated the `jenkins.version` property from `${jenkins.baseline}.3` to `${jenkins.baseline}.1`.